### PR TITLE
Fix indexing bug with pinthreads()

### DIFF
--- a/src/pinning.jl
+++ b/src/pinning.jl
@@ -167,6 +167,10 @@ function pinthreads(pinning::PinningStrategy;
     return nothing
 end
 function pinthreads(pinning::Symbol; kwargs...)
+    if !is_valid_pinning_symbol(pinning)
+        throw(ArgumentError("Unknown pinning strategy: $(pinning)"))
+    end
+
     pinthreads(_pinning_symbol2singleton(pinning); kwargs...)
 end
 

--- a/test/pinning_test.jl
+++ b/test/pinning_test.jl
@@ -132,3 +132,16 @@ end
     pinthreads(reverse(cpuids); force = false)
     @test getcpuids() == cpuids
 end
+
+@testset "Thread Pinning (random)" begin
+    pinthreads(0:nthreads() - 1)
+
+    cpuids = Vector{Vector{Int64}}()
+    for _ in 1:10
+        pinthreads(:random)
+        push!(cpuids, getcpuids())
+    end
+
+    # Check that at least some of the pinning settings were different
+    @test any([any(x .!= cpuids[1]) for x in cpuids[2:end]])
+end

--- a/test/pinning_test.jl
+++ b/test/pinning_test.jl
@@ -134,7 +134,7 @@ end
 end
 
 @testset "Thread Pinning (random)" begin
-    pinthreads(0:nthreads() - 1)
+    pinthreads(getcpuids())
 
     cpuids = Vector{Vector{Int64}}()
     for _ in 1:10
@@ -143,5 +143,5 @@ end
     end
 
     # Check that at least some of the pinning settings were different
-    @test any([any(x .!= cpuids[1]) for x in cpuids[2:end]])
+    @test any(x != cpuids[1] for x in cpuids)
 end

--- a/test/pinning_test.jl
+++ b/test/pinning_test.jl
@@ -134,8 +134,6 @@ end
 end
 
 @testset "Thread Pinning (random)" begin
-    pinthreads(getcpuids())
-
     cpuids = Vector{Vector{Int64}}()
     for _ in 1:10
         pinthreads(:random)


### PR DESCRIPTION
When the `:random` strategy is selected `pinthreads()` will default to ignoring
hyperthreads, but in this case the number of CPU IDs returned will be less than
the total number of threads available, and taking a view of the returned CPU IDs
will fail since the end index is out of bounds. There are probably other
situations that would trigger this.