### PR TITLE
Fix Intel MKL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,16 +12,18 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 
 [compat]
+MKL = "0.6"
 Preferences = "1"
 SnoopPrecompile = "1"
 TestItemRunner = "0.2"
 julia = "1.6"
 
 [extras]
+MKL = "33e6dc65-8f57-5167-99aa-e5a354878fb2"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Test", "Random", "TestItemRunner", "Statistics"]
+test = ["Test", "Random", "TestItemRunner", "Statistics", "MKL"]

--- a/src/mkl.jl
+++ b/src/mkl.jl
@@ -1,18 +1,10 @@
 """
-Check if MKL library (`libmkl_rt`) is available in `Libdl.dllist()` (as is the case when
-loading [MKL.jl](https://github.com/JuliaLinearAlgebra/MKL.jl) or
-[MKL_jll.jl](https://github.com/JuliaBinaryWrappers/MKL_jll.jl)).
-"""
-function mkl_is_available()
-    any(endswith(lib, "libmkl_rt.$(Libdl.dlext)") for lib in Libdl.dllist())
-end
-
-"""
-Check whether Intel MKL is currently loaded (via libblastrampoline).
+Check whether Intel MKL is currently loaded via libblastrampoline (Julia >= 1.7)
+or is available in `Libdl.dllist()` (Julia 1.6).
 """
 function mkl_is_loaded()
     @static if VERSION <= v"1.7-"
-        mkl_is_available()
+        any(endswith(lib, "libmkl_rt.$(Libdl.dlext)") for lib in Libdl.dllist())
     else
         any(x -> startswith(x, "libmkl_rt"),
             basename(lib.libname) for lib in BLAS.get_config().loaded_libs)
@@ -20,15 +12,50 @@ function mkl_is_loaded()
 end
 
 """
+Returns the full path to the `libmkl_rt` library if the latter is loaded. Will try to
+locate the library and, if successfull, will cache the result. Throws an error otherwise.
+
+To force an update of the cache, provide `force_update=true`.
+"""
+function mkl_fullpath(; force_update = false)
+    if isnothing(MKL_PATH[]) || force_update
+        mklpath = _find_mkl()
+        MKL_PATH[] = mklpath
+    end
+    return MKL_PATH[]
+end
+
+# locate libmkl_rt (i.e. full path to it)
+function _find_mkl()
+    @static if VERSION <= v"1.7-"
+        mklidx = findfirst(lib -> endswith(lib, "libmkl_rt.$(Libdl.dlext)"), Libdl.dllist())
+        if isnothing(mklidx)
+            error("Intel MKL not loaded.")
+        end
+        fullpath = Libdl.dllist()[mklidx]
+    else
+        mklidx = findfirst(lib -> startswith(basename(lib.libname), "libmkl_rt"),
+                           BLAS.get_config().loaded_libs)
+        if isnothing(mklidx)
+            error("Intel MKL not loaded via LBT.")
+        end
+        fullpath = BLAS.get_config().loaded_libs[mklidx].libname
+    end
+    return fullpath
+end
+
+"""
     mkl_get_dynamic()
 Wrapper around the MKL function [`mkl_get_dynamic`](https://www.intel.com/content/www/us/en/develop/documentation/onemkl-developer-reference-fortran/top/support-functions/threading-control/mkl-get-dynamic.html).
 """
-mkl_get_dynamic() = @ccall dlpath("libmkl_rt").mkl_get_dynamic()::Cint
+mkl_get_dynamic() = @ccall mkl_fullpath().mkl_get_dynamic()::Cint
 
 """
     mkl_set_dynamic(flag::Integer)
 Wrapper around the MKL function [`mkl_set_dynamic`](https://www.intel.com/content/www/us/en/develop/documentation/onemkl-developer-reference-c/top/support-functions/threading-control/mkl-set-dynamic.html).
 """
 function mkl_set_dynamic(flag::Integer)
-    @ccall dlpath("libmkl_rt").MKL_Set_Dynamic(flag::Cint)::Cvoid
+    @ccall mkl_fullpath().MKL_Set_Dynamic(flag::Cint)::Cvoid
 end
+
+const MKL_PATH = Ref{Union{Nothing, String}}(nothing)

--- a/test/mkl_test.jl
+++ b/test/mkl_test.jl
@@ -1,0 +1,17 @@
+using ThreadPinning
+using Test
+using MKL
+
+@testset "MKL utilities" begin
+    @test ThreadPinning.mkl_is_loaded()
+    @test ThreadPinning.mkl_get_dynamic() isa Integer
+    @test isnothing(ThreadPinning.mkl_set_dynamic(1))
+    @test ThreadPinning.mkl_get_dynamic() == 1
+    @test isnothing(ThreadPinning.mkl_set_dynamic(0))
+    @test ThreadPinning.mkl_get_dynamic() == 0
+end
+
+@testset "MKL threadinfo" begin
+    @test isnothing(threadinfo())
+    @test isnothing(threadinfo(; blas = true, hints = true))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,3 +15,4 @@ Threads.nthreads() ≥ 4 ||
 @testitem "likwid-pin" begin include("likwid-pin_test.jl") end
 @testitem "openblas" begin include("openblas_test.jl") end
 @testitem "core2core latency" begin include("latency_test.jl") end
+@testitem "intel mkl" begin include("mkl_test.jl") end


### PR DESCRIPTION
Closes #48

The issue was that `dlpath` errors despite having done `using MKL` (presumably because the artefact, `libmkl_rt`, doesn't go onto the `LD_LIBRARY_PATH`). Fixed it by querying the full path to `libmkl_rt` from `BLAS.get_config()` on Julia >= 1.7.