### PR TITLE
API for setting thread affinity ("loosely pinning threads")

### DIFF
--- a/src/ThreadPinning.jl
+++ b/src/ThreadPinning.jl
@@ -22,6 +22,7 @@ include("querying.jl")
 include("slurm.jl")
 include("pinning.jl")
 include("pinning_mpi.jl")
+include("setaffinity.jl")
 include("likwid-pin.jl")
 include("mkl.jl")
 include("openblas.jl")
@@ -100,6 +101,7 @@ PrecompileTools.@compile_workload begin @static if Sys.islinux()
     pinthreads(:numa; nthreads = 1, compact = true)
     pinthreads(:random; nthreads = 1)
     pinthreads(:current; nthreads = 1)
+    setaffinity(node(1:2))
     getcpuid()
     getcpuids()
     nsockets()
@@ -133,11 +135,13 @@ export threadinfo,
        pinthreads_likwidpin,
        pinthreads_mpi,
        pinthread,
+       setaffinity,
        getcpuids,
        getcpuid,
        unpinthreads,
        unpinthread,
        @tspawnat,
+       print_affinity_mask,
        print_affinity_masks,
        ncputhreads,
        ncores,

--- a/src/pinning.jl
+++ b/src/pinning.jl
@@ -161,7 +161,7 @@ function pinthreads(::Val{:affinitymask}; hyperthreads_last = true,
     if !all(isequal(mask), masks)
         error("Julia threads have different affinity masks.")
     end
-    cpuids = get_cpuids_from_affinity_mask(mask)
+    cpuids = affinitymask2cpuids(mask)
     if length(cpuids) < nthreads
         error("More Julia threads than CPU-threads specified by affinity mask.")
     end
@@ -230,7 +230,7 @@ end
 
 function _check_cpuids(cpuids)
     if !all(c -> c in cpuids_all(), cpuids)
-        throw(ArgumentError("Inavlid CPU ID encountered. See `cpuids_all()` for all " *
+        throw(ArgumentError("Invalid CPU ID encountered. See `cpuids_all()` for all " *
                             "valid CPU IDs on the system."))
     end
     return nothing

--- a/src/setaffinity.jl
+++ b/src/setaffinity.jl
@@ -1,0 +1,33 @@
+"""
+$(TYPEDSIGNATURES)Set the affinity of the calling Julia thread to the given CPU-threads.
+
+*Example:*
+* `setaffinity(socket(1))` # set the affinity to the first socket
+* `setaffinity(numa(2))` # set the affinity to the second NUMA domain
+* `setaffinity(socket(1, 1:3))` # set the affinity to the first three cores in the first NUMA domain
+* `setaffinity([1,3,5])` # set the affinity to the CPU-threads with the IDs 1, 3, and 5.
+"""
+function setaffinity(cpuids::AbstractVector{<:Integer})
+    _check_cpuids(cpuids)
+    mask = cpuids2affinitymask(cpuids)
+    uv_thread_setaffinity(mask)
+    return nothing
+end
+"""
+$(TYPEDSIGNATURES)Set the affinity of a specific Julia thread to the given CPU-threads.
+"""
+function setaffinity(threadid::Integer, cpuids::AbstractVector{<:Integer}; kwargs...)
+    fetch(@tspawnat threadid setaffinity(cpuids; kwargs...))
+    return nothing
+end
+
+function cpuids2affinitymask(cpuids::AbstractVector{<:Integer})
+    masksize = uv_cpumask_size()
+    cpumask = zeros(Cchar, masksize)
+    for (i,c) in pairs(cpuids_all())
+        if c in cpuids
+            cpumask[i] = one(Cchar)
+        end
+    end
+    return cpumask
+end

--- a/src/threadinfo.jl
+++ b/src/threadinfo.jl
@@ -139,7 +139,7 @@ function threadinfo(io = getstdout(); blas = false, hints = false, color = true,
         end
     end
     if masks
-        print_affinity_masks(io; groupby, threadpool)
+        print_affinity_masks(; groupby, threadpool, io)
     end
     hints && _general_hints()
     return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ end
 @testitem "querying" begin include("tests_querying.jl") end
 @testitem "threadinfo" begin include("tests_threadinfo.jl") end
 @testitem "pinning" begin include("tests_pinning.jl") end
+@testitem "setaffinity" begin include("tests_setaffinity.jl") end
 
 @testitem "likwid-pin" begin include("tests_likwid-pin.jl") end
 @testitem "openblas" begin include("tests_openblas.jl") end

--- a/test/tests_querying.jl
+++ b/test/tests_querying.jl
@@ -27,6 +27,8 @@ ThreadPinning.update_sysinfo!(; fromscratch = true)
     @test typeof(cpuids_per_socket()) == Vector{Vector{Int}}
     @test ishyperthread(0) == false
     @test isnothing(print_affinity_masks())
+    @test isnothing(print_affinity_mask())
+    @test isnothing(print_affinity_mask(1))
 end
 
 @static if VERSION >= v"1.9-"

--- a/test/tests_setaffinity.jl
+++ b/test/tests_setaffinity.jl
@@ -1,0 +1,17 @@
+include("common.jl")
+using Test
+using ThreadPinning
+
+@testset "Set/Get Thread Affinity" begin
+    # calling thread
+    for cpuids in (node(1:2), node(2:3), socket(1), nsockets() >= 2 ? socket(2, 1:2) : numa(1, 1:2))
+        @test isnothing(setaffinity(cpuids))
+        @test ThreadPinning.get_cpuids_from_affinity_mask() == cpuids
+    end
+
+    # other thread
+    for cpuids in (node(1:2), node(2:3), socket(1), nsockets() >= 2 ? socket(2, 1:2) : numa(1, 1:2))
+        @test isnothing(setaffinity(1, cpuids))
+        @test ThreadPinning.get_cpuids_from_affinity_mask(1) == cpuids
+    end
+end


### PR DESCRIPTION
(cc @vchuravy)
 
<img width="1233" alt="Screenshot 2023-07-04 at 21 20 15" src="https://github.com/carstenbauer/ThreadPinning.jl/assets/187980/825ff739-6aa5-4ada-ab9d-4f0b05a970c5">

Would probably be nice to also have a function `setaffinities` that sets the affinity of all threads, e.g., in an alternating fashion (similar to `pinthreads`). But I'll leave that for a different PR.

Close #67