### PR TITLE
Make `pinthreads` and co no-ops on Windows/macOS

### DIFF
--- a/src/ThreadPinning.jl
+++ b/src/ThreadPinning.jl
@@ -8,7 +8,7 @@ import Random
 using DelimitedFiles
 using DocStringExtensions
 
-const DEFAULT_IO = Ref{Union{IO,Nothing}}(nothing)
+const DEFAULT_IO = Ref{Union{IO, Nothing}}(nothing)
 getstdout() = something(DEFAULT_IO[], stdout)
 
 # includes
@@ -29,6 +29,12 @@ include("utility.jl")
     include("openblas.jl")
     include("threadinfo.jl")
     include("latency.jl")
+else
+    pinthreads(args...; kwargs...) = nothing
+    pinthread(args...; kwargs...) = nothing
+    setaffinity(args...; kwargs...) = nothing
+    pinthreads_likwidpin(args...; kwargs...) = nothing
+    pinthreads_mpi(args...; kwargs...) = nothing
 end
 include("preferences.jl")
 
@@ -80,7 +86,8 @@ function __init__()
         end
         maybe_autopin()
     else
-        # Nothing for now.
+        @warn("Operating system not supported by ThreadPinning.jl."*
+              " Functions like `pinthreads` will be no-ops!")
     end
     return nothing
 end

--- a/src/ThreadPinning.jl
+++ b/src/ThreadPinning.jl
@@ -13,21 +13,23 @@ getstdout() = something(DEFAULT_IO[], stdout)
 
 # includes
 include("utility.jl")
-include("sysinfo.jl")
-include("lscpu_examples.jl")
-include("libs/libc.jl")
-include("libs/libuv.jl")
-include("libs/libpthread.jl")
-include("querying.jl")
-include("slurm.jl")
-include("pinning.jl")
-include("pinning_mpi.jl")
-include("setaffinity.jl")
-include("likwid-pin.jl")
-include("mkl.jl")
-include("openblas.jl")
-include("threadinfo.jl")
-include("latency.jl")
+@static if Sys.islinux()
+    include("sysinfo.jl")
+    include("lscpu_examples.jl")
+    include("libs/libc.jl")
+    include("libs/libuv.jl")
+    include("libs/libpthread.jl")
+    include("querying.jl")
+    include("slurm.jl")
+    include("pinning.jl")
+    include("pinning_mpi.jl")
+    include("setaffinity.jl")
+    include("likwid-pin.jl")
+    include("mkl.jl")
+    include("openblas.jl")
+    include("threadinfo.jl")
+    include("latency.jl")
+end
 include("preferences.jl")
 
 function _try_get_autoupdate()
@@ -78,8 +80,7 @@ function __init__()
         end
         maybe_autopin()
     else
-        error("Operating system not supported. ThreadPinning.jl currently only supports " *
-              "Linux.")
+        # Nothing for now.
     end
     return nothing
 end

--- a/src/ThreadPinning.jl
+++ b/src/ThreadPinning.jl
@@ -86,7 +86,7 @@ function __init__()
         end
         maybe_autopin()
     else
-        os_warning = get(ENV, "TP_OS_WARNING", Prefs.get_os_warning())
+        os_warning = Prefs.get_os_warning()
         if isnothing(os_warning) || parse(Bool, os_warning)
             @warn("Operating system not supported by ThreadPinning.jl."*
                   " Functions like `pinthreads` will be no-ops!")

--- a/src/ThreadPinning.jl
+++ b/src/ThreadPinning.jl
@@ -87,7 +87,7 @@ function __init__()
         maybe_autopin()
     else
         os_warning = get(ENV, "TP_OS_WARNING", Prefs.get_os_warning())
-        if os_warning
+        if isnothing(os_warning) || os_warning
             @warn("Operating system not supported by ThreadPinning.jl."*
                   " Functions like `pinthreads` will be no-ops!")
         end

--- a/src/ThreadPinning.jl
+++ b/src/ThreadPinning.jl
@@ -89,7 +89,8 @@ function __init__()
         os_warning = Prefs.get_os_warning()
         if isnothing(os_warning) || os_warning
             @warn("Operating system not supported by ThreadPinning.jl."*
-                  " Functions like `pinthreads` will be no-ops!")
+                  " Functions like `pinthreads` will be no-ops!\n" *
+                  "(Hide this warning via `ThreadPinning.Prefs.set_os_warning(false)`.)")
         end
     end
     return nothing

--- a/src/ThreadPinning.jl
+++ b/src/ThreadPinning.jl
@@ -87,7 +87,7 @@ function __init__()
         maybe_autopin()
     else
         os_warning = get(ENV, "TP_OS_WARNING", Prefs.get_os_warning())
-        if isnothing(os_warning) || os_warning
+        if isnothing(os_warning) || parse(Bool, os_warning)
             @warn("Operating system not supported by ThreadPinning.jl."*
                   " Functions like `pinthreads` will be no-ops!")
         end

--- a/src/ThreadPinning.jl
+++ b/src/ThreadPinning.jl
@@ -87,7 +87,7 @@ function __init__()
         maybe_autopin()
     else
         os_warning = Prefs.get_os_warning()
-        if isnothing(os_warning) || parse(Bool, os_warning)
+        if isnothing(os_warning) || os_warning
             @warn("Operating system not supported by ThreadPinning.jl."*
                   " Functions like `pinthreads` will be no-ops!")
         end

--- a/src/ThreadPinning.jl
+++ b/src/ThreadPinning.jl
@@ -86,8 +86,11 @@ function __init__()
         end
         maybe_autopin()
     else
-        @warn("Operating system not supported by ThreadPinning.jl."*
-              " Functions like `pinthreads` will be no-ops!")
+        os_warning = get(ENV, "TP_OS_WARNING", Prefs.get_os_warning())
+        if os_warning
+            @warn("Operating system not supported by ThreadPinning.jl."*
+                  " Functions like `pinthreads` will be no-ops!")
+        end
     end
     return nothing
 end

--- a/src/pinning.jl
+++ b/src/pinning.jl
@@ -230,7 +230,9 @@ end
 
 function _check_cpuids(cpuids)
     if !all(c -> c in cpuids_all(), cpuids)
-        throw(ArgumentError("Invalid CPU ID encountered. See `cpuids_all()` for all " *
+        valid_cpuids = cpuids_all()
+        problem_cpuids = filter(c -> !(c in valid_cpuids), cpuids)
+        throw(ArgumentError("Invalid CPU ID(s) encountered: $(problem_cpuids). See `cpuids_all()` for all " *
                             "valid CPU IDs on the system."))
     end
     return nothing

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -4,7 +4,7 @@ using Preferences
 using DocStringExtensions
 using ..ThreadPinning: getstdout
 
-const ALL_PREFERENCES = ("autoupdate", "pin", "likwidpin")
+const ALL_PREFERENCES = ("autoupdate", "pin", "likwidpin", "os_warning")
 
 "Query whether the pin preference is set"
 has_pin() = @has_preference("pin")
@@ -72,6 +72,31 @@ end
 "$(SIGNATURES)Set the autoupdate preference"
 function set_autoupdate(b::Bool)
     @set_preferences!("autoupdate"=>string(b))
+    @info("Done. Package might recompile next time it is loaded (in a new Julia session).")
+    return nothing
+end
+
+"Query whether the OS warning preference is set"
+has_os_warning() = @has_preference("os_warning")
+
+"Get the OS warning preference. Returns `nothing` if not set."
+function get_os_warning()
+    p = @load_preference("os_warning")
+    if isnothing(p)
+        return nothing #default
+    else
+        try
+            b = parse(Bool, lowercase(p))
+            return b
+        catch
+            throw(ArgumentError("`$p` is not a valid value for the OS warning preference"))
+        end
+    end
+end
+
+"$(SIGNATURES)Set the OS warning preference"
+function set_os_warning(b::Bool)
+    @set_preferences!("os_warning"=>string(b))
     @info("Done. Package might recompile next time it is loaded (in a new Julia session).")
     return nothing
 end

--- a/test/tests_latency.jl
+++ b/test/tests_latency.jl
@@ -3,6 +3,9 @@ using ThreadPinning
 import ThreadPinning: bench_core2core_latency
 using Test
 
+ThreadPinning.update_sysinfo!(; fromscratch = true)
+
 @testset "bench_core2core_latency" begin
-    @test bench_core2core_latency(0:3; nbench = 1) isa Matrix{Float64}
+    cores = node(1:4)
+    @test bench_core2core_latency(cores; nbench = 1) isa Matrix{Float64}
 end

--- a/test/tests_preferences.jl
+++ b/test/tests_preferences.jl
@@ -6,6 +6,10 @@ using Test
     @test ThreadPinning.Prefs.get_autoupdate() == false
     @test isnothing(ThreadPinning.Prefs.set_autoupdate(true))
 
+    @test isnothing(ThreadPinning.Prefs.set_os_warning(false))
+    @test ThreadPinning.Prefs.get_os_warning() == false
+    @test isnothing(ThreadPinning.Prefs.set_os_warning(true))
+
     @test isnothing(ThreadPinning.Prefs.set_pin(:sockets))
     @test ThreadPinning.Prefs.get_pin() == "sockets"
     @test isnothing(ThreadPinning.Prefs.set_pin("cores"))


### PR DESCRIPTION
I decided to display a warning on `using ThreadPinning` on Windows and macOS as not informing the user at all that the package isn't going to work on these OSs doesn't seem right. The warning can be disabled by setting the preference `os_warning=false`. A helper function for this is `ThreadPinning.Prefs.set_os_warning(false)`.

After `using ThreadPinning`, `pinthreads` and co will be no-ops (i.e. not show a warning!) on Windows and macOS.

As a package author that wants to specify a default pinning in a package, you can of course always load ThreadPinning conditionally if you don't like the warning, i.e. for example:
```julia
@static if Sys.islinux()
	using ThreadPinning
	pinthreads(:numa)
end
```

(cc @oschulz)

Closes #78