### PR TITLE
Print affinity info to correct IO stream

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThreadPinning"
 uuid = "811555cd-349b-4f26-b7bc-1f208b848042"
 authors = ["Carsten Bauer <crstnbr@gmail.com> and contributors"]
-version = "0.7.22"
+version = "0.7.23"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/threadinfo.jl
+++ b/src/threadinfo.jl
@@ -73,7 +73,7 @@ function threadinfo(io = getstdout(); blas = false, hints = false, color = true,
 
     # visualize current pinning
     println(io)
-    _visualize_affinity(; thread_cpuids, color, groupby, slurm, kwargs...)
+    _visualize_affinity(io; thread_cpuids, color, groupby, slurm, kwargs...)
 
     # extra information
     print(io, "Julia threads: ")
@@ -244,13 +244,13 @@ function _visualize_affinity(io = getstdout();
     end
     if groupby in (:sockets, :socket)
         printstyled(io, "|"; bold = true)
-        print(io, " = Socket seperator")
+        print(io, " = Socket separator")
     elseif groupby in (:numa, :NUMA)
         printstyled(io, "|"; bold = true)
-        print(io, " = NUMA seperator")
+        print(io, " = NUMA separator")
     elseif groupby in (:core, :cores)
         printstyled(io, "|"; bold = true)
-        print(io, " = Core seperator")
+        print(io, " = Core separator")
     end
     println(io, "\n")
     return nothing


### PR DESCRIPTION
I noticed when playing around with ThreadPinning.jl and MPI.jl that
when redirecting the output of different MPI ranks to separate files,
the affinity information was printed to the main log file.